### PR TITLE
Fix build error

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,6 @@
 # -- Project information -----------------------------------------------------
 
-project = 'Lana's Profile'
+project = "Lana's Profile"
 copyright = '2023, Lana Taychack'
 author = 'Lana Taychack'
 


### PR DESCRIPTION
You were getting an error (red x) because of an issue in your `conf.py` file. 

You had it like 
```Python
project = 'Lana's Profile'
```

notice how as Python the `s Profile'` is a different color than `'Lana'`.

In Python (the .py tells us the file is Python) we can use single quotes `'` or double quotes `"` to enclose strings (words) except if we want to use one of those characters **inside** our string, then we have to use the other to enclose. 

Since you want an apostrophe, which is a single quote, you have to use double quotes on the outside. 

```Python
project = "Lana's Profile"
```

You can see how I changed it on files changed and then merge this PR. 

